### PR TITLE
/version route

### DIFF
--- a/lib/noah/app.rb
+++ b/lib/noah/app.rb
@@ -48,6 +48,11 @@ module Noah
 
       haml :index, :format => :html5, :locals => {:redis_version => Ohm.redis.info["redis_version"].to_s, :noah_version => Noah::VERSION}
     end
+  
+    get '/version' do
+      content_type "application/json"
+      {:redis_version => Ohm.redis.info["redis_version"].to_s, :noah_version => Noah::VERSION}.to_json
+    end
 
     not_found do
       content_type "application/json"


### PR DESCRIPTION
Added a route for version in the following format:

<pre>{"redis_version":"2.0.1","noah_version":"0.8.6"}</pre>

This lets us simplify a couple validation tests we run against noah, instead of parsing it out of the html index.
