### PR TITLE
Soften requirement on eventmachine

### DIFF
--- a/noah.gemspec
+++ b/noah.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("eventmachine", ["1.0.0.beta.3"])
+  s.add_dependency("eventmachine", ["> 1.0.0.beta.3"])
   s.add_dependency("em-http-request", ["1.0.0.beta.4"])
   s.add_dependency("redis", ["= 2.2.0"])
   s.add_dependency("nest", "= 1.1.0")


### PR DESCRIPTION
Requiring noah clashes with some other libraries that import eventmachine 1.0.0.beta4.
