### PR TITLE
Previously applications/configurations used a `set` instead of a `collection`

### DIFF
--- a/lib/noah/models/applications.rb
+++ b/lib/noah/models/applications.rb
@@ -4,7 +4,7 @@ module Noah
     include Taggable
     include Linkable
     attribute :name
-    set :configurations, Configuration
+    collection :configurations, Configuration
 
     index :name
     index :configurations

--- a/lib/noah/models/configurations.rb
+++ b/lib/noah/models/configurations.rb
@@ -11,12 +11,14 @@ module Noah
     index :format
     index :body
 
+    reference :application, Application
+
     def validate
       super
       assert_present :name
       assert_present :format
       assert_present :body
-      assert_unique :name
+      assert_unique  [:application_id, :name]
     end
 
     def to_hash

--- a/lib/noah/version.rb
+++ b/lib/noah/version.rb
@@ -1,3 +1,3 @@
 module Noah
-  VERSION = "0.8.6"
+  VERSION = "0.9.0"
 end

--- a/noah.gemspec
+++ b/noah.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |s|
   s.add_dependency("guid", ["= 0.1.1"])
   s.add_dependency("slop", ["= 2.1.0"])
 
+  s.add_dependency 'em-hiredis',                      '~> 0.1.0'
+  s.add_dependency 'em-http-request',                 '~> 1.0.0.beta.4'
 
   if RUBY_PLATFORM =~ /java/
     s.add_dependency("jruby-openssl")

--- a/noah.gemspec
+++ b/noah.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency("em-http-request", ["1.0.0.beta.4"])
   s.add_dependency("redis", ["= 2.2.0"])
   s.add_dependency("nest", "= 1.1.0")
-  s.add_dependency("rack", "= 1.3.4")
+  s.add_dependency("rack", "= 1.3.5")
   s.add_dependency("tilt", "= 1.3.3")
   s.add_dependency("sinatra", "= 1.3.1")
   s.add_dependency("rack-protection", "= 1.1.4")

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -79,6 +79,34 @@ describe "Using the Configuration Model", :reset_redis => true do
       c.has_key?(b.name.to_s).should == true
       c.each {|k,v| v.keys.map {|k| k.to_s}.sort.should == ['created_at','format','updated_at']}
     end
+
+    it "should allow for multiple configrations values with the same name with different applications" do
+      a1 = Noah::Application.create(:name => "test-app-1")
+      a1.valid?.should == true
+      a1.is_new?.should == true
+      b1 = Noah::Application.find(:name => "test-app-1").first
+      b1.should == a1
+
+      a2 = Noah::Application.create(:name => "test-app-2")
+      a2.valid?.should == true
+      a2.is_new?.should == true
+      b2 = Noah::Application.find(:name => "test-app-2").first
+      b2.should == a2
+
+      c1 = Noah::Configuration.create(@appconf_string.merge(:application_id => a1.id))
+      c2 = Noah::Configuration.create(@appconf_string.merge(:application_id => a2.id))
+
+      c1.valid?.should == true
+      c1.is_new?.should == true
+      b1 = Noah::Configuration[c1.id]
+      b1.should == c1
+
+      c2.valid?.should == true
+      c2.is_new?.should == true
+      b2 = Noah::Configuration[c2.id]
+      b2.should == c2
+    end
+
   end
 
   describe "should not" do
@@ -100,7 +128,7 @@ describe "Using the Configuration Model", :reset_redis => true do
     it "create a duplicate Configuration" do
       a = Noah::Configuration.create(@appconf_string)
       b = Noah::Configuration.create(@appconf_string)
-      b.errors.should == [[:name, :not_unique]]
+      b.errors.should == [[[:application_id, :name], :not_unique]]
     end
   end
 


### PR DESCRIPTION
According to wiki an application id is `required` for configurations: https://github.com/lusis/Noah/wiki/Configuration

This change is mostly backwards compatible except a migration is may be needed for converting a `set` to a `collection`.

The old behaviour of creating a configuration without an application still exists. However it now uses `assert_unique` on `[:application_id, :name]`

Bumps the version to `0.9.0` so as not to break anyones application until ready.

Also added `em-hiredis`, `em-http-request` as dependencies for ease.

Added a test, all tests appear to be passing but please take a careful review for anything I may have missed.
